### PR TITLE
renamed content_upload_url property

### DIFF
--- a/src/Ayamel/ApiBundle/Controller/V1/CreateResource.php
+++ b/src/Ayamel/ApiBundle/Controller/V1/CreateResource.php
@@ -64,7 +64,7 @@ class CreateResource extends ApiController
 
         //define returned content structure
         return $this->createServiceResponse(array(
-            'content_upload_url' => $uploadUrl,
+            'contentUploadUrl' => $uploadUrl,
             'resource' => $resource
         ), 201);
     }

--- a/src/Ayamel/ApiBundle/Controller/V1/RequestContentUpload.php
+++ b/src/Ayamel/ApiBundle/Controller/V1/RequestContentUpload.php
@@ -37,7 +37,7 @@ class RequestContentUpload extends ApiController
 
         $url = $this->container->get('router')->generate('api_v1_upload_content', array('id' => $resource->getId(), 'token' => $uploadToken), true);
 
-        return $this->createServiceResponse(array('content_upload_url' => $url), 200);
+        return $this->createServiceResponse(array('contentUploadUrl' => $url), 200);
     }
 
 }

--- a/src/Ayamel/ApiBundle/Tests/ContentUploadIntegrationTest.php
+++ b/src/Ayamel/ApiBundle/Tests/ContentUploadIntegrationTest.php
@@ -23,7 +23,7 @@ class ContentUploadIntegrationTest extends ApiTestCase
         $this->assertFalse(isset($response['resource']['content']));
 
         $resourceId = $response['resource']['id'];
-        $apiPath = substr($response['content_upload_url'], strlen('http://localhost'));
+        $apiPath = substr($response['contentUploadUrl'], strlen('http://localhost'));
 
         //hit the path with empty request, expect 422 (unprocessable) - then 401 on subsequent requests
         $response = $this->getResponse('POST', $apiPath.'?_key=45678isafgd56789asfgdhf4567');
@@ -41,8 +41,8 @@ class ContentUploadIntegrationTest extends ApiTestCase
         $this->assertSame(200, $response->getStatusCode());
         $content = json_decode($response->getContent(), true);
         $this->assertSame(200, $content['response']['code']);
-        $this->assertTrue(isset($content['content_upload_url']));
-        $uploadUrl = substr($content['content_upload_url'], strlen('http://localhost'));
+        $this->assertTrue(isset($content['contentUploadUrl']));
+        $uploadUrl = substr($content['contentUploadUrl'], strlen('http://localhost'));
 
         $response = $this->getResponse('POST', $uploadUrl.'?_key=45678isafgd56789asfgdhf4567');
         $this->assertSame(422, $response->getStatusCode());
@@ -59,8 +59,8 @@ class ContentUploadIntegrationTest extends ApiTestCase
         $this->assertSame(200, $response->getStatusCode());
         $content = json_decode($response->getContent(), true);
         $this->assertSame(200, $content['response']['code']);
-        $this->assertTrue(isset($content['content_upload_url']));
-        $uploadUrl = substr($content['content_upload_url'], strlen('http://localhost'));
+        $this->assertTrue(isset($content['contentUploadUrl']));
+        $uploadUrl = substr($content['contentUploadUrl'], strlen('http://localhost'));
         
         //no apikey
         $response = $this->getResponse('POST', $uploadUrl);
@@ -87,7 +87,7 @@ class ContentUploadIntegrationTest extends ApiTestCase
         $this->assertSame('awaiting_content', $response['resource']['status']);
 
         $resourceId = $response['resource']['id'];
-        $apiPath = substr($response['content_upload_url'], strlen('http://localhost'));
+        $apiPath = substr($response['contentUploadUrl'], strlen('http://localhost'));
 
         $data = array(
             'remoteFiles' => array(
@@ -142,7 +142,7 @@ class ContentUploadIntegrationTest extends ApiTestCase
         $this->assertSame(201, $response['response']['code']);
         $this->assertFalse(isset($response['resource']['content']));
         $resourceId = $response['resource']['id'];
-        $uploadUrl = substr($response['content_upload_url'], strlen('http://localhost'));
+        $uploadUrl = substr($response['contentUploadUrl'], strlen('http://localhost'));
 
         //create uploaded file
         $testFilePath = __DIR__."/files/resource_test_files/lorem.txt";
@@ -181,7 +181,7 @@ class ContentUploadIntegrationTest extends ApiTestCase
         $this->assertFalse(isset($response['resource']['content']));
         $this->assertSame('awaiting_content', $response['resource']['status']);
         $resourceId = $response['resource']['id'];
-        $uploadUrl = substr($response['content_upload_url'], strlen('http://localhost'));
+        $uploadUrl = substr($response['contentUploadUrl'], strlen('http://localhost'));
 
         //create uploaded file
         $testFilePath = __DIR__."/files/resource_test_files/lorem.txt";

--- a/src/Ayamel/ApiBundle/Tests/ResourceIntegrationTest.php
+++ b/src/Ayamel/ApiBundle/Tests/ResourceIntegrationTest.php
@@ -107,7 +107,7 @@ class ResourceIntegrationTest extends ApiTestCase
         $this->assertSame($json['resource']['dateModified'], $json['resource']['dateAdded']);
         $this->assertFalse(isset($json['resource']['content']));
         $this->assertFalse(isset($json['resource']['relations']));
-        $this->assertTrue(isset($json['content_upload_url']));
+        $this->assertTrue(isset($json['contentUploadUrl']));
     }
 
     public function testCreateNewResourceIgnoresReadOnlyFields()
@@ -212,7 +212,7 @@ class ResourceIntegrationTest extends ApiTestCase
         $this->assertSame($json['resource']['dateModified'], $json['resource']['dateAdded']);
         $this->assertFalse(isset($json['resource']['content']));
         $this->assertFalse(isset($json['resource']['relations']));
-        $this->assertTrue(isset($json['content_upload_url']));
+        $this->assertTrue(isset($json['contentUploadUrl']));
 
         //use these in subsequent tests
         $dateAdded = $json['resource']['dateAdded'];
@@ -266,7 +266,7 @@ class ResourceIntegrationTest extends ApiTestCase
         $this->assertFalse($modified['resource']['dateModified'] === $modified['resource']['dateAdded']);
         $this->assertFalse(isset($modified['resource']['content']));
         $this->assertFalse(isset($modified['resource']['relations']));
-        $this->assertFalse(isset($modified['content_upload_url']));
+        $this->assertFalse(isset($modified['contentUploadUrl']));
 
         //setting a field to null should remove it
         sleep(1);   //sleeping one second to force dateModified to be different
@@ -301,7 +301,7 @@ class ResourceIntegrationTest extends ApiTestCase
         $this->assertFalse($prevDateModified === $modified['resource']['dateModified']);
         $this->assertFalse(isset($modified['resource']['content']));
         $this->assertFalse(isset($modified['resource']['relations']));
-        $this->assertFalse(isset($modified['content_upload_url']));
+        $this->assertFalse(isset($modified['contentUploadUrl']));
     }
 
     public function testDeleteResource()
@@ -366,7 +366,7 @@ class ResourceIntegrationTest extends ApiTestCase
         $this->assertSame($json['resource']['dateModified'], $json['resource']['dateAdded']);
         $this->assertFalse(isset($json['resource']['content']));
         $this->assertFalse(isset($json['resource']['relations']));
-        $this->assertTrue(isset($json['content_upload_url']));
+        $this->assertTrue(isset($json['contentUploadUrl']));
 
         $resourceId = $json['resource']['id'];
 


### PR DESCRIPTION
renamed to `contentUploadUrl` to match the convention used everywhere else

Closes #92 
