### PR TITLE
implemented & tested proper file attributes validation

### DIFF
--- a/src/Ayamel/ApiBundle/Tests/ContentUploadIntegrationTest.php
+++ b/src/Ayamel/ApiBundle/Tests/ContentUploadIntegrationTest.php
@@ -100,8 +100,10 @@ class ContentUploadIntegrationTest extends ApiTestCase
                     'mime' => 'video/mp4; encoding=binary',
                     'mimeType' => 'video/mp4',
                     'attributes' => array(
-                        'key' => 'val',
-                        'foo' => 'bar'
+                        'frameSize' => array(
+                            'height' => 1080,
+                            'width' => 1920
+                        ),
                     )
                 ),
                 array(
@@ -113,8 +115,10 @@ class ContentUploadIntegrationTest extends ApiTestCase
                     'mime' => 'video/mp4; encoding=binary',
                     'mimeType' => 'video/mp4',
                     'attributes' => array(
-                        'key' => 'val',
-                        'foo' => 'bar'
+                        'frameSize' => array(
+                            'height' => 400,
+                            'width' => 600
+                        ),
                     )
                 )
             )
@@ -126,6 +130,8 @@ class ContentUploadIntegrationTest extends ApiTestCase
         $this->assertSame(200, $response['response']['code']);
         $this->assertSame($data['remoteFiles'], $response['resource']['content']['files']);
         $this->assertSame('normal', $response['resource']['status']);
+        
+        //TODO: test failing attributes
     }
 
     public function testUploadContentAsFile()

--- a/src/Ayamel/ResourceBundle/Resources/config/config.yml
+++ b/src/Ayamel/ResourceBundle/Resources/config/config.yml
@@ -9,16 +9,74 @@ parameters:
     ayamel.resource.null_extension_type: data
 
     ayamel.resource.file_attribute_validation_map:
-        Ayamel\ResourceBundle\Validation\File\VideoAttributes:
+        Ayamel\ResourceBundle\Validation\File\GenericVideoAttributes:
             - video/mp4
             - video/x-ms-wmv
             - video/avi
-        Ayamel\ResourceBundle\Validation\File\AudioAttributes:
+            - video/msvideo
+            - video/x-msvideo
+            - video/avs-video
+            - video/mpeg
+            - video/x-motion-jpeg
+            - video/x-mpeg
+            - video/quicktime
+            - video/webm
+            - video/ogg
+            - video/x-matroska
+            - video/x-flv
+        Ayamel\ResourceBundle\Validation\File\GenericAudioAttributes:
             - audio/mp3
             - audio/aac
-        Ayamel\ResourceBundle\Validation\File\ImageAttributes: []
-        Ayamel\ResourceBundle\Validation\File\DocumentAttributes: []
-        Ayamel\ResourceBundle\Validation\File\DataAttributes: []
+            - audio/x-aac
+            - audio/basic
+            - audio/L24
+            - audio/mp4
+            - audio/mpeg
+            - audio/ogg
+            - audio/vorbis
+            - audio/vnd.rn-realaudio
+            - audio/vnd.wave
+            - audio/webm
+        Ayamel\ResourceBundle\Validation\File\GenericImageAttributes: 
+            - image/gif
+            - image/jpeg
+            - image/pjpeg
+            - image/svg+xml
+            - image/png
+            - image/tiff
+            - image/x-xcf
+        Ayamel\ResourceBundle\Validation\File\GenericDocumentAttributes: 
+            - text/plain
+            - text/vcard
+            - application/pdf
+            - application/x-latex
+            - application/msword
+            - application/vnd.oasis.opendocument.text
+            - application/vnd.oasis.opendocument.spreadsheet
+            - application/vnd.oasis.opendocument.presentation
+            - application/vnd.oasis.opendocument.graphics
+            - application/vnd.ms-excel
+            - application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
+            - application/vnd.ms-powerpoint
+            - application/vnd.openxmlformats-officedocument.presentationml.presentation
+            - application/vnd.openxmlformats-officedocument.wordprocessingml.document
+            - application/x-iwork-keynote-sffkey
+            - application/x-iwork-pages-sffpages
+            - application/x-iwork-numbers-sffnumbers
+        Ayamel\ResourceBundle\Validation\File\GenericDataAttributes: 
+            - application/xml
+            - application/json
+            - text/csv
+            - application/x-yaml
+            - text/yaml
+        Ayamel\ResourceBundle\Validation\File\GenericArchiveAttributes: 
+            - application/zip
+            - application/gzip
+            - application/x-rar-compressed
+            - application/x-tar
+        Ayamel\ResourceBundle\Validation\File\CaptionAttributes:
+            - text/vtt
+            - text/srt
 
     ayamel.resource.relation_attribute_validation_map:
         depends_on: ~

--- a/src/Ayamel/ResourceBundle/Resources/config/validation.yml
+++ b/src/Ayamel/ResourceBundle/Resources/config/validation.yml
@@ -294,41 +294,108 @@ Ayamel\ResourceBundle\Document\Relation:
 ## FILE ATTRIBUTES
 ##
 
-Ayamel\ResourceBundle\Validation\File\VideoAttributes:
+Ayamel\ResourceBundle\Validation\File\GenericVideoAttributes:
     properties:
-        resolutionX:
-            - Type:
-                type: integer
-            - Range:
-                min: 0
-        resolutionY:
-            - Type:
-                type: integer
-            - Range:
-                min: 0
+        frameSize:
+            - Collection:
+                allowExtraFields: false
+                allowMissingFields: false
+                fields:
+                    height:
+                        - Type:
+                            type: integer
+                        - Range:
+                            min: 0
+                    width:
+                        - Type:
+                            type: integer
+                        - Range:
+                            min: 0
         duration:
             - Type:
                 type: integer
             - Range:
                 min: 0
-        averageBitrate:
+        aspectRatio:
+            - Type:
+                type: string
+            - Ayamel\ResourceBundle\Validation\AspectRatioConstraint: ~
+        bitrate:
+            - Type:
+                type: integer
+            - Range:
+                min: 0
+        frameRate:
             - Type:
                 type: integer
             - Range:
                 min: 0
 
-Ayamel\ResourceBundle\Validation\File\AudioAttributes:
+Ayamel\ResourceBundle\Validation\File\GenericAudioAttributes:
     properties:
         duration:
             - Type:
                 type: integer
             - Range:
                 min: 0
-        averageBitrate:
+        bitrate:
             - Type:
                 type: integer
             - Range:
                 min: 0
+        channels:
+            - Type:
+                type: integer
+            - Range:
+                min: 0
+
+Ayamel\ResourceBundle\Validation\File\GenericImageAttributes:
+    properties:
+        frameSize:
+            - Collection:
+                allowExtraFields: false
+                allowMissingFields: false
+                fields:
+                    height:
+                        - Type:
+                            type: integer
+                        - Range:
+                            min: 0
+                    width:
+                        - Type:
+                            type: integer
+                        - Range:
+                            min: 0
+        aspectRatio:
+            - Type:
+                type: string
+            - Ayamel\ResourceBundle\Validation\AspectRatioConstraint: ~
+        time:
+            - Type:
+                type: integer
+            - Range:
+                min: 0
+        units:
+            - Type:
+                type: string
+            - Length:
+                max: 250
+                
+Ayamel\ResourceBundle\Validation\File\GenericDocumentAttributes:
+    properties:
+        pages:
+            - Type:
+                type: integer
+            - Range:
+                min: 0
+                
+Ayamel\ResourceBundle\Validation\File\CaptionAttributes:
+    properties:
+        duration:
+            - Type:
+                type: integer
+            - Range:
+                min: 0            
 
 ##
 ## RELATION ATTRIBUTES

--- a/src/Ayamel/ResourceBundle/Tests/AbstractAttributesTest.php
+++ b/src/Ayamel/ResourceBundle/Tests/AbstractAttributesTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Ayamel\ResourceBundle\Tests;
+
+use Ayamel\ResourceBundle\Validation\AbstractAttributes;
+
+class FooAttributes extends AbstractAttributes
+{
+    public $foo;
+}
+
+class AbstractAttributesTest extends \PHPUnit_Framework_TestCase
+{
+    
+    public function testInstantiateWithData()
+    {
+        $obj = FooAttributes::createFromArray(array('foo' => 'bar'));
+        
+        $this->assertTrue($obj instanceof AbstractAttributes);
+        $this->assertTrue($obj instanceof FooAttributes);
+        $this->assertSame('bar', $obj->foo);
+        $extras = $obj->getExtraFields();
+        $this->assertTrue(empty($extras));
+    }
+    
+    public function testInstantiateWithExtraFields()
+    {
+        $obj = FooAttributes::createFromArray(array('foo' => 'bar', 'baz' => 23));
+        $extras = $obj->getExtraFields();
+        $this->assertSame(1, count($extras));
+        $this->assertSame('baz', $extras[0]);
+    }
+    
+}

--- a/src/Ayamel/ResourceBundle/Validation/AbstractAttributes.php
+++ b/src/Ayamel/ResourceBundle/Validation/AbstractAttributes.php
@@ -15,18 +15,25 @@ abstract class AbstractAttributes
 
     public static function createFromArray(array $data)
     {
+        $extras = array();
         $obj = new static();
         foreach ($data as $key => $val) {
             if (property_exists($obj, $key)) {
                 $obj->$key = $val;
             } else {
-                $extraFields[] = $key;
+                $extras[] = $key;
             }
         }
 
+        $obj->setExtraFields($extras);
         return $obj;
     }
-
+    
+    public function setExtraFields(array $extras)
+    {
+        $this->extraFields = $extras;
+    }
+    
     public function getExtraFields()
     {
         return $this->extraFields;

--- a/src/Ayamel/ResourceBundle/Validation/AspectRatioConstraint.php
+++ b/src/Ayamel/ResourceBundle/Validation/AspectRatioConstraint.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Ayamel\ResourceBundle\Validation;
+
+use Symfony\Component\Validator\Constraint;
+
+/*
+ * Invokes checks for a valid aspect ratio string.
+ *
+ * @Annotation
+ */
+class AspectRatioConstraint extends Constraint
+{
+    public $message = "Invalid aspect ratio.  Should be in the format '[int]:[int]' or '[float]:[int]'.";
+
+    public function validatedBy()
+    {
+        return 'Ayamel\ResourceBundle\Validation\AspectRatioValidator';
+    }
+}

--- a/src/Ayamel/ResourceBundle/Validation/AspectRatioValidator.php
+++ b/src/Ayamel/ResourceBundle/Validation/AspectRatioValidator.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Ayamel\ResourceBundle\Validation;
+
+use Symfony\Component\Validator\ValidatorInterface;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+/*
+ * Validates aspect ratio strings.
+ */
+class AspectRatioValidator extends ConstraintValidator
+{
+    public function validate($value, Constraint $constraint)
+    {
+        $exp = explode(':', $value);
+        
+        if (count($exp) !== 2) {
+            //if it equals 0, it means it's a scalable vector image, so the
+            //aspect ratio can change
+            if (0 == $value) {
+                return;
+            }
+
+            $this->context->addViolation($constraint->message);
+        }
+        
+        if (!is_numeric($exp[0]) || !is_int((int) $exp[1])) {
+            $this->context->addViolation($constraint->message);
+        }
+    }
+}

--- a/src/Ayamel/ResourceBundle/Validation/File/CaptionAttributes.php
+++ b/src/Ayamel/ResourceBundle/Validation/File/CaptionAttributes.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Ayamel\ResourceBundle\Validation\File;
+
+use Ayamel\ResourceBundle\Validation\AbstractAttributes;
+
+/**
+ * Defines properties for validating caption file attributes.
+ *
+ * @package AyamelResourceBundle
+ * @author Evan Villemez
+ */
+class CaptionAttributes extends AbstractAttributes
+{
+    public $duration;
+}

--- a/src/Ayamel/ResourceBundle/Validation/File/GenericArchiveAttributes.php
+++ b/src/Ayamel/ResourceBundle/Validation/File/GenericArchiveAttributes.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Ayamel\ResourceBundle\Validation\File;
+
+use Ayamel\ResourceBundle\Validation\AbstractAttributes;
+
+/**
+ * Defines properties for validating archive file attributes.
+ *
+ * @package AyamelResourceBundle
+ * @author Evan Villemez
+ */
+class GenericArchiveAttributes extends AbstractAttributes
+{
+}

--- a/src/Ayamel/ResourceBundle/Validation/File/GenericAudioAttributes.php
+++ b/src/Ayamel/ResourceBundle/Validation/File/GenericAudioAttributes.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Ayamel\ResourceBundle\Validation\File;
+
+use Ayamel\ResourceBundle\Validation\AbstractAttributes;
+
+/**
+ * Defines properties for validating audio file attributes.
+ *
+ * @package AyamelResourceBundle
+ * @author Evan Villemez
+ */
+class GenericAudioAttributes extends AbstractAttributes
+{
+    public $duration;
+    public $bitrate;
+    public $channels;
+}

--- a/src/Ayamel/ResourceBundle/Validation/File/GenericDataAttributes.php
+++ b/src/Ayamel/ResourceBundle/Validation/File/GenericDataAttributes.php
@@ -5,13 +5,11 @@ namespace Ayamel\ResourceBundle\Validation\File;
 use Ayamel\ResourceBundle\Validation\AbstractAttributes;
 
 /**
- * Defines properties for validating audio file attributes.
+ * Defines properties for validating data file attributes.
  *
  * @package AyamelResourceBundle
  * @author Evan Villemez
  */
-class AudioAttributes extends AbstractAttributes
+class GenericDataAttributes extends AbstractAttributes
 {
-    public $duration;
-    public $averageBitrate;
 }

--- a/src/Ayamel/ResourceBundle/Validation/File/GenericDocumentAttributes.php
+++ b/src/Ayamel/ResourceBundle/Validation/File/GenericDocumentAttributes.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Ayamel\ResourceBundle\Validation\File;
+
+use Ayamel\ResourceBundle\Validation\AbstractAttributes;
+
+/**
+ * Defines properties for validating document file attributes.
+ *
+ * @package AyamelResourceBundle
+ * @author Evan Villemez
+ */
+class GenericDocumentAttributes extends AbstractAttributes
+{
+    public $pages;
+}

--- a/src/Ayamel/ResourceBundle/Validation/File/GenericImageAttributes.php
+++ b/src/Ayamel/ResourceBundle/Validation/File/GenericImageAttributes.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Ayamel\ResourceBundle\Validation\File;
+
+use Ayamel\ResourceBundle\Validation\AbstractAttributes;
+
+/**
+ * Defines properties for validating image file attributes.
+ *
+ * @package AyamelResourceBundle
+ * @author Evan Villemez
+ */
+class GenericImageAttributes extends AbstractAttributes
+{
+    public $frameSize;
+    public $time;
+    public $aspectRatio;
+    public $units;
+}

--- a/src/Ayamel/ResourceBundle/Validation/File/GenericVideoAttributes.php
+++ b/src/Ayamel/ResourceBundle/Validation/File/GenericVideoAttributes.php
@@ -5,15 +5,16 @@ namespace Ayamel\ResourceBundle\Validation\File;
 use Ayamel\ResourceBundle\Validation\AbstractAttributes;
 
 /**
- * Defines properties for validating video files attributes.
+ * Defines properties for validating video file attributes.
  *
  * @package AyamelResourceBundle
  * @author Evan Villemez
  */
-class VideoAttributes extends AbstractAttributes
+class GenericVideoAttributes extends AbstractAttributes
 {
-    public $resolutionX;
-    public $resolutionY;
+    public $frameSize;
     public $duration;
-    public $averageBitrate;
+    public $aspectRatio;
+    public $frameRate;
+    public $bitrate;
 }

--- a/src/Ayamel/ResourceBundle/Validation/FileAttributesValidator.php
+++ b/src/Ayamel/ResourceBundle/Validation/FileAttributesValidator.php
@@ -23,38 +23,63 @@ class FileAttributesValidator extends ConstraintValidator
 
     public function validate($object, Constraint $constraint)
     {
+        //all file attributes are optional from a validation standpoint. If there are none, it is valid
+        $fileAttributes = $object->getAttributes();
+        if (empty($fileAttributes)) {
+            return;
+        }
+        
         $mime = $object->getMimeType();
-        $attrs = $this->createAttributesClass($mime, $object->getAttributes());
-        if (!$attrs) {
+        $attrs = $this->getAttributesClasses($mime, $object->getAttributes());
+        if (empty($attrs)) {
             $this->context->addViolationAt('mimeType', sprintf("Files with mimeType [%s] cannot be validated.", $mime));
 
             return;
         }
 
-        $errors = $this->validator->validate($attrs);
+        $errors = array();
 
+        //validate each applicable attributes class
+        foreach ($attrs as $attr) {
+            $failures = $this->validator->validate($attr);
+            if (!empty($failures)) {
+                foreach ($failures as $fail) {
+                    $errors[] = $fail;
+                }
+            }
+        }
+        
+        //add violations, if any
         if (count($errors) > 0) {
             foreach ($errors as $error) {
                 $this->context->addViolationAt('attributes', $error);
             }
         }
 
-        //check for extra fields
-        if (count($attrs->getExtraFields()) > 0) {
-            foreach ($attrs->getExtraFields() as $field) {
-                $this->context->addViolationAt('attributes', $field." is not a valid field.");
+        //check for fields that were NOT validated by any of the mapped attributes classes
+        $total = count($attrs);
+        $extras = array();
+        foreach ($attrs as $attr) {
+            foreach ($attr->getExtraFields() as $field) {
+                $extras[$field] = (isset($extras[$field])) ? $extras[$field] + 1 : 1;
+            }
+        }
+        foreach ($extras as $field => $count) {
+            if ($count >= $total) {
+                $this->context->addViolationAt('attributes', $field." is not a valid attribute for this type of file.");
             }
         }
     }
 
-    protected function createAttributesClass($mime, $data)
+    protected function getAttributesClasses($mime, $data)
     {
+        $classes = array();
         foreach ($this->map as $class => $mimes) {
             if (in_array($mime, $mimes)) {
-                return $class::createFromArray($data);
+                $classes[] = $class::createFromArray($data);
             }
         }
 
-        return false;
+        return $classes;
     }
 }


### PR DESCRIPTION
Closes #58

Further additions/modifications to file attributes validation should be opened as a separate issue.

More than one attributes class can now be applied to a mimeType.  The map for which classes apply to which mimeTypes is defined in the property `ayamel.resource.file_attribute_validation_map` in `src/Ayamel/ResourceBundle/Resources/config/config.yml`

Extraneous file attributes will cause validation to fail, otherwise that data would end up persisting to the database.  This is slightly different from the behavior in the rest of the API where bad input is filtered out early on and just ignored.
