### PR TITLE
implemented and tested proper relation attributes

### DIFF
--- a/src/Ayamel/ApiBundle/Tests/RelationsIntegrationTest.php
+++ b/src/Ayamel/ApiBundle/Tests/RelationsIntegrationTest.php
@@ -78,9 +78,9 @@ class RelationsIntegrationTest extends ApiTestCase
         $relationData = array(
             'subjectId' => $subjectId,
             'objectId' => $objectId,
-            'type' => 'requires',
+            'type' => 'version_of',
             'attributes' => array(
-                'foo' => 'bar'
+                'version' => '12.23.45'
             ),
             'clientUser' => array(
                 'id' => 'user1',
@@ -320,9 +320,6 @@ class RelationsIntegrationTest extends ApiTestCase
             'subjectId' => $subjectId,
             'objectId' => $objectId,
             'type' => 'requires',
-            'attributes' => array(
-                'foo' => 'bar'
-            ),
             'clientUser' => array(
                 'id' => 'user1',
                 'url' => 'http://example.com/users/user1'

--- a/src/Ayamel/ResourceBundle/Document/Relation.php
+++ b/src/Ayamel/ResourceBundle/Document/Relation.php
@@ -47,9 +47,13 @@ class Relation
     /**
      * The type of the Relation.  Valid types include:
      *
-     * - **part_of** - words here...
-     * - **requires** - words here...
-     * - **depends_on** - words here...
+     * - **based_on** - The subject is a performance, production, derivation, adaptation, or interpretation of the object resource.
+     * - **references** - The subject cites or otherwise refers to the object resource.
+     * - **requires** - The subject requires the object for its functioning, delivery, or content and cannot be used without the related resource being present.
+     * - **transcript_of** - The subject is a linear description of a time-based object (e.g., a text transcript of audio)
+     * - **search** - Content for the object resource will affect hits against the subject resource when searching.  Only owners of the subject Resource may create `search` relations.
+     * - **version_of** - The subject is a historical state or edition of the object resource.
+     * - **part_of** - The subject is a physical or logical part of the object resource.
      *
      * @MongoDB\String
      * @JMS\Type("string")

--- a/src/Ayamel/ResourceBundle/Resources/config/config.yml
+++ b/src/Ayamel/ResourceBundle/Resources/config/config.yml
@@ -79,9 +79,12 @@ parameters:
             - text/srt
 
     ayamel.resource.relation_attribute_validation_map:
-        depends_on: ~
+        based_on: ~
+        references: ~
         requires: ~
-        derived_from: ~
+        transcript_of: ~
+        search: ~
+        version_of: Ayamel\ResourceBundle\Validation\Relation\VersionOfAttributes
         part_of: Ayamel\ResourceBundle\Validation\Relation\PartOfAttributes
 
 services:

--- a/src/Ayamel/ResourceBundle/Resources/config/validation.yml
+++ b/src/Ayamel/ResourceBundle/Resources/config/validation.yml
@@ -288,7 +288,7 @@ Ayamel\ResourceBundle\Document\Relation:
         type:
             - NotBlank: ~
             - Choice:
-                choices: [part_of, requires, depends_on]
+                choices: [based_on, references, requires, transcript_of, search, version_of, part_of]
 
 ##
 ## FILE ATTRIBUTES
@@ -408,3 +408,11 @@ Ayamel\ResourceBundle\Validation\Relation\PartOfAttributes:
                 type: integer
             - Range:
                 min: 0
+
+Ayamel\ResourceBundle\Validation\Relation\VersionOfAttributes:
+    properties:
+        version:
+            - Type:
+                type: string
+            - Length:
+                max: 500

--- a/src/Ayamel/ResourceBundle/Tests/RelationValidationTest.php
+++ b/src/Ayamel/ResourceBundle/Tests/RelationValidationTest.php
@@ -13,7 +13,7 @@ use Ayamel\ResourceBundle\Document\Relation;
  */
 class RelationValidationTest extends ApiTestCase
 {
-    public function testNoErrorsOnUnmappedOrNullRelation()
+    public function testPassValidationOnUnmappedOrNullRelation()
     {
         $v = $this->getContainer()->get('validator');
 
@@ -24,23 +24,67 @@ class RelationValidationTest extends ApiTestCase
 
         $errors = $v->validate($rel);
 
-        $this->assertSame(0, count($errors));        
+        $this->assertSame(0, count($errors));
     }
 
-    public function testValidatePartOfAttributes()
+    public function testFailsValidationWithExtraKeys()
+    {
+        $v = $this->getContainer()->get('validator');
+        
+        //unmapped w/ extra key
+        $rel = new Relation();
+        $rel->setObjectId('324');
+        $rel->setSubjectId('325');
+        $rel->setType('requires');
+        $rel->setAttributes(array(
+            'foo' => 'bar'
+        ));
+        $errors = $v->validate($rel);
+        $this->assertSame(1, count($errors));
+        
+        //mapped w/ extra key
+        $rel = new Relation();
+        $rel->setObjectId('324');
+        $rel->setSubjectId('325');
+        $rel->setType('part_of');
+        $rel->setAttributes(array(
+            'foo' => 'bar'
+        ));
+        $errors = $v->validate($rel);
+        $this->assertSame(1, count($errors));
+    }
+    
+    
+    
+    public function testValidatePartOfRelation()
     {
         $rel = new Relation();
         $rel->setObjectId('324');
         $rel->setSubjectId('325');
         $rel->setType('part_of');
         $rel->setAttributes(array(
-            'index' => 23.3
+            'index' => 3
         ));
 
         $v = $this->getContainer()->get('validator');
         $errors = $v->validate($rel);
 
-        $this->assertSame(1, count($errors));
-        $this->assertSame('attributes', $errors[0]->getPropertyPath());
+        $this->assertSame(0, count($errors));
+    }
+    
+    public function testValidateVersionOfRelation()
+    {
+        $rel = new Relation();
+        $rel->setObjectId('324');
+        $rel->setSubjectId('325');
+        $rel->setType('version_of');
+        $rel->setAttributes(array(
+            'version' => "99.23.33"
+        ));
+
+        $v = $this->getContainer()->get('validator');
+        $errors = $v->validate($rel);
+
+        $this->assertSame(0, count($errors));
     }
 }

--- a/src/Ayamel/ResourceBundle/Validation/Relation/VersionOfAttributes.php
+++ b/src/Ayamel/ResourceBundle/Validation/Relation/VersionOfAttributes.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Ayamel\ResourceBundle\Validation\Relation;
+
+use Ayamel\ResourceBundle\Validation\AbstractAttributes;
+
+/**
+ * Defines properties for validating `version_of` Relation attributes.
+ *
+ * @package AyamelResourceBundle
+ * @author Evan Villemez
+ */
+class VersionOfAttributes extends AbstractAttributes
+{
+    public $version;
+}

--- a/src/Ayamel/ResourceBundle/Validation/RelationAttributesValidator.php
+++ b/src/Ayamel/ResourceBundle/Validation/RelationAttributesValidator.php
@@ -23,19 +23,34 @@ class RelationAttributesValidator extends ConstraintValidator
     public function validate($object, Constraint $constraint)
     {
         $type = $object->getType($object);
-
+        $attrs = $object->getAttributes();
+        
+        //check map for validation class
         if (!isset($this->map[$type]) || is_null($this->map[$type])) {
+            if (empty($attrs)) {
+                return;
+            }
+            
+            //if not mapped and there are attributes, it's invalid
+            $this->context->addViolationAt('attributes', sprintf("Relation of type [%s] cannot contain attributes.", $type));
             return;
         }
 
+        //create validation class and validate the attributes
         $class = $this->map[$type];
         $attrs = $class::createFromArray($object->getAttributes());
 
+        //add validation errors
         $errors = $this->validator->validate($attrs);
-
+        $extras = $attrs->getExtraFields();
         if (count($errors) > 0) {
             foreach ($errors as $error) {
                 $this->context->addViolationAt('attributes', $error->getMessage());
+            }
+        }
+        if (!empty($extras)) {
+            foreach ($extras as $field) {
+                $this->context->addViolationAt('attributes', sprintf("[%s] is an invalid attribute for Relations of type [%s]", $field, $type));
             }
         }
     }


### PR DESCRIPTION
Closes #54

Extraneous attributes on Relations will cause validation to fail.  At the moment this differs from behavior elsewhere in the API where bad input is ignored early on during deserialization.

Further changes/modifications to Relation attributes should be opened as separate issues.
